### PR TITLE
feat: Add child resource endpoints with expand support (series and instances child)

### DIFF
--- a/examples/series/main.go
+++ b/examples/series/main.go
@@ -143,16 +143,29 @@ func main() {
 	// Example: GetSeriesInstances
 
 	if len(expandedSeries) > 0 {
-		seriesInstances, err := client.GetSeriesInstances(expandedSeries[0].ID)
+		instanceIDs, err := client.GetSeriesInstances(expandedSeries[0].ID)
 		if err != nil {
-			log.Fatalf("Failed get series stats: %v", err)
+			log.Fatalf("Failed to get series instances: %v", err)
 		}
+		fmt.Printf("Found %d instances in series %s\n", len(instanceIDs), expandedSeries[0].ID)
+		fmt.Println(instanceIDs)
+	}
 
-		jsonData, err := json.MarshalIndent(seriesInstances, "", "  ")
-		if err != nil { 
-			log.Fatalf("Failed to marshal series: %v ", err)
+	// Example: GetSeriesInstancesExpanded
+
+	if len(expandedSeries) > 0 {
+		instances, err := client.GetSeriesInstancesExpanded(expandedSeries[0].ID)
+		if err != nil {
+			log.Fatalf("Failed to get expanded series instances: %v", err)
 		}
-		
-		fmt.Println(string(jsonData))	
-	}	
+		fmt.Printf("Found %d instances with full details in series %s\n", len(instances), expandedSeries[0].ID)
+
+		for _, i := range instances {
+			jsonData, err := json.MarshalIndent(i, "", "  ")
+			if err != nil {
+				log.Fatalf("Failed to marshal instance: %v", err)
+			}
+			fmt.Println(string(jsonData))
+		}
+	}
 }

--- a/examples/studies/main.go
+++ b/examples/studies/main.go
@@ -115,4 +115,62 @@ func main() {
 		}
 		fmt.Printf("Study archive downloaded to: study_%s.zip\n", expandedStudies[0].ID)
 	}
+
+	// Example: GetStudySeries
+
+	if len(expandedStudies) > 0 {
+		seriesIDs, err := client.GetStudySeries(expandedStudies[0].ID)
+		if err != nil {
+			log.Fatalf("Failed to get study series: %v", err)
+		}
+		fmt.Printf("Found %d series in study %s\n", len(seriesIDs), expandedStudies[0].ID)
+		fmt.Println(seriesIDs)
+	}
+
+	// Example: GetStudySeriesExpanded
+
+	if len(expandedStudies) > 0 {
+		series, err := client.GetStudySeriesExpanded(expandedStudies[0].ID)
+		if err != nil {
+			log.Fatalf("Failed to get expanded study series: %v", err)
+		}
+		fmt.Printf("Found %d series with full details in study %s\n", len(series), expandedStudies[0].ID)
+
+		for _, s := range series {
+			jsonData, err := json.MarshalIndent(s, "", "  ")
+			if err != nil {
+				log.Fatalf("Failed to marshal series: %v", err)
+			}
+			fmt.Println(string(jsonData))
+		}
+	}
+
+	// Example: GetStudyInstances
+
+	if len(expandedStudies) > 0 {
+		instanceIDs, err := client.GetStudyInstances(expandedStudies[0].ID)
+		if err != nil {
+			log.Fatalf("Failed to get study instances: %v", err)
+		}
+		fmt.Printf("Found %d instances in study %s\n", len(instanceIDs), expandedStudies[0].ID)
+		fmt.Println(instanceIDs)
+	}
+
+	// Example: GetStudyInstancesExpanded
+
+	if len(expandedStudies) > 0 {
+		instances, err := client.GetStudyInstancesExpanded(expandedStudies[0].ID)
+		if err != nil {
+			log.Fatalf("Failed to get expanded study instances: %v", err)
+		}
+		fmt.Printf("Found %d instances with full details in study %s\n", len(instances), expandedStudies[0].ID)
+
+		for _, i := range instances {
+			jsonData, err := json.MarshalIndent(i, "", "  ")
+			if err != nil {
+				log.Fatalf("Failed to marshal instance: %v", err)
+			}
+			fmt.Println(string(jsonData))
+		}
+	}
 }

--- a/series.go
+++ b/series.go
@@ -99,10 +99,20 @@ func (c *Client) GetSeriesStatistics(seriesID string) (*types.Statistics, error)
 }
 
 
-// Only accepts expand false for now
 func (c *Client) GetSeriesInstances(seriesID string) ([]string, error) {
-	var instances []string
+	var instanceIDs []string
 	path := fmt.Sprintf("series/%s/instances?expand=false", seriesID)
+
+	if err := c.get(path, &instanceIDs); err != nil {
+		return nil, err
+	}
+
+	return instanceIDs, nil
+}
+
+func (c *Client) GetSeriesInstancesExpanded(seriesID string) ([]types.Instance, error) {
+	var instances []types.Instance
+	path := fmt.Sprintf("series/%s/instances?expand=true", seriesID)
 
 	if err := c.get(path, &instances); err != nil {
 		return nil, err

--- a/studies.go
+++ b/studies.go
@@ -149,3 +149,47 @@ func (c *Client) GetStudyStatistics(studyID string) (*types.Statistics, error) {
 
 	return &stats, nil
 }
+
+func (c *Client) GetStudySeries(studyID string) ([]string, error) {
+	var seriesIDs []string
+	path := fmt.Sprintf("studies/%s/series?expand=false", studyID)
+
+	if err := c.get(path, &seriesIDs); err != nil {
+		return nil, err
+	}
+
+	return seriesIDs, nil
+}
+
+func (c *Client) GetStudySeriesExpanded(studyID string) ([]types.Series, error) {
+	var series []types.Series
+	path := fmt.Sprintf("studies/%s/series?expand=true", studyID)
+
+	if err := c.get(path, &series); err != nil {
+		return nil, err
+	}
+
+	return series, nil
+}
+
+func (c *Client) GetStudyInstances(studyID string) ([]string, error) {
+	var instanceIDs []string
+	path := fmt.Sprintf("studies/%s/instances?expand=false", studyID)
+
+	if err := c.get(path, &instanceIDs); err != nil {
+		return nil, err
+	}
+
+	return instanceIDs, nil
+}
+
+func (c *Client) GetStudyInstancesExpanded(studyID string) ([]types.Instance, error) {
+	var instances []types.Instance
+	path := fmt.Sprintf("studies/%s/instances?expand=true", studyID)
+
+	if err := c.get(path, &instances); err != nil {
+		return nil, err
+	}
+
+	return instances, nil
+}


### PR DESCRIPTION
Closes #1 

Add child resource endpoints with expand support StudySeries, GetStudyInstances, and GetSeriesInstances methods with both compact and expanded response options following Orthanc API patterns.