### PR TITLE
fix: Fix boolean omitempty issue and add BoolPtr helper.

### DIFF
--- a/examples/instances/main.go
+++ b/examples/instances/main.go
@@ -131,8 +131,8 @@ func main() {
 		defer output.Close()
 
 		anonymizeRequest := &types.InstancesAnonymizeRequest{
-			Force: false,
-			KeepSource: true,
+			Force:      gorthanc.BoolPtr(false),
+			KeepSource: gorthanc.BoolPtr(true),
 		}
 
 		resp, err := client.AnonymizeInstance(insId, anonymizeRequest)

--- a/examples/patients/main.go
+++ b/examples/patients/main.go
@@ -55,9 +55,9 @@ func main() {
 
 	if len(patients) > 0 {
 		anonymizeRequest := &types.PatientAnonymizeRequest{
-			Force: false,
-			Permissive: false,
-			KeepSource: true,
+			Force:      gorthanc.BoolPtr(false),
+			Permissive: gorthanc.BoolPtr(false),
+			KeepSource: gorthanc.BoolPtr(true),
 		}
 		anonymizedPatient, err := client.AnonymizePatient(patients[0], anonymizeRequest)
 		if err != nil {

--- a/examples/series/main.go
+++ b/examples/series/main.go
@@ -88,9 +88,9 @@ func main() {
 
 	if len(expandedSeries) > 0 {
 		anonymizeRequest := &types.SeriesAnonymizeRequest{
-			Force: false,
-			Permissive: false,
-			KeepSource: true,
+			Force:      gorthanc.BoolPtr(false),
+			Permissive: gorthanc.BoolPtr(false),
+			KeepSource: gorthanc.BoolPtr(true),
 		}
 		anonymizedSeries, err := client.AnonymizeSeries(expandedSeries[0].ID, anonymizeRequest)
 		if err != nil {

--- a/examples/studies/main.go
+++ b/examples/studies/main.go
@@ -81,9 +81,9 @@ func main() {
 
 	if len(expandedStudies) > 0 {
 		anonymizeRequest := &types.StudyAnonymizeRequest{
-			Force: false,
-			Permissive: false,
-			KeepSource: true,
+			Force:      gorthanc.BoolPtr(false),
+			Permissive: gorthanc.BoolPtr(false),
+			KeepSource: gorthanc.BoolPtr(true),
 		}
 		anonymizedStudy, err := client.AnonymizeStudy(expandedStudies[0].ID, anonymizeRequest)
 		if err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,8 @@
+package gorthanc
+
+// BoolPtr returns a pointer to the given bool value.
+// This is a helper function for creating pointers to bool literals,
+// which is commonly needed when working with API request structs.
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/patients.go
+++ b/patients.go
@@ -43,7 +43,7 @@ func (c *Client) GetPatientDetails(patientID string) (*types.Patient, error) {
 func (c *Client) AnonymizePatient(studyID string, anonymizeRequest *types.PatientAnonymizeRequest) (*types.PatientAnonymizeResponse, error) {
 	var result types.PatientAnonymizeResponse
 	path := fmt.Sprintf("patients/%s/anonymize", studyID)
-	anonymizeRequest.Asynchronous = false	
+	anonymizeRequest.Asynchronous = BoolPtr(false)
 
 	if err := c.post(path, anonymizeRequest, &result); err != nil {
 		return nil, err

--- a/series.go
+++ b/series.go
@@ -70,8 +70,7 @@ func (c *Client) DeleteSeries(seriesID string) error {
 func (c *Client) AnonymizeSeries(seriesID string, anonymizeRequest *types.SeriesAnonymizeRequest) (*types.SeriesAnonymizeResponse, error) {
 	var result types.SeriesAnonymizeResponse
 	path := fmt.Sprintf("series/%s/anonymize", seriesID)
-	anonymizeRequest.Asynchronous = false
-	
+	anonymizeRequest.Asynchronous = BoolPtr(false)
 
 	if err := c.post(path, anonymizeRequest, &result); err != nil {
 		return nil, err

--- a/studies.go
+++ b/studies.go
@@ -108,7 +108,7 @@ func (c *Client) DeleteStudy(studyID string) error {
 func (c *Client) AnonymizeStudy(studyID string, anonymizeRequest *types.StudyAnonymizeRequest) (*types.StudyAnonymizeResponse, error) {
 	var result types.StudyAnonymizeResponse
 	path := fmt.Sprintf("studies/%s/anonymize", studyID)
-	anonymizeRequest.Asynchronous = false	
+	anonymizeRequest.Asynchronous = BoolPtr(false)
 
 	if err := c.post(path, anonymizeRequest, &result); err != nil {
 		return nil, err

--- a/types/instance.go
+++ b/types/instance.go
@@ -157,19 +157,19 @@ type GetInstanceTagsQueryParams struct {
 // AnonymizeRequest represents a request to anonymize a instance
 type InstancesAnonymizeRequest struct {
 	// If true, the REST API will return a Job ID and the job will be put in a queue
-	Asynchronous bool `json:"Asynchronous,omitempty"`
+	Asynchronous *bool `json:"Asynchronous,omitempty"`
 
 	// DicomVersion to use for anonymization
 	DicomVersion string `json:"DicomVersion,omitempty"`
 
 	// Force operation even if it would create an invalid DICOM file
-	Force bool `json:"Force,omitempty"`	
+	Force *bool `json:"Force,omitempty"`
 
 	// By default orthanc does not exclude the source study, use set this to falso to delete after the anonymization proccess
-	KeepSource bool `json:"KeepSource,omitempty"`	
+	KeepSource *bool `json:"KeepSource,omitempty"`
 
 	// If true, ignore errors during the individual steps of the job.
-	Permissive bool `json:"Permissive,omitempty"`
+	Permissive *bool `json:"Permissive,omitempty"`
 
 	// Defines the priority of the job (Only work on async mode, which isn't implemented)
 	Priority int `json:"Priority,omitempty"`

--- a/types/modality.go
+++ b/types/modality.go
@@ -15,19 +15,19 @@ type Modality struct {
 	Manufacturer string `json:"Manufacturer,omitempty"`
 
 	// Whether to allow echo requests
-	AllowEcho bool `json:"AllowEcho,omitempty"`
+	AllowEcho *bool `json:"AllowEcho,omitempty"`
 
 	// Whether to allow C-FIND requests
-	AllowFind bool `json:"AllowFind,omitempty"`
+	AllowFind *bool `json:"AllowFind,omitempty"`
 
 	// Whether to allow C-GET requests
-	AllowGet bool `json:"AllowGet,omitempty"`
+	AllowGet *bool `json:"AllowGet,omitempty"`
 
 	// Whether to allow C-MOVE requests
-	AllowMove bool `json:"AllowMove,omitempty"`
+	AllowMove *bool `json:"AllowMove,omitempty"`
 
 	// Whether to allow C-STORE requests
-	AllowStore bool `json:"AllowStore,omitempty"`
+	AllowStore *bool `json:"AllowStore,omitempty"`
 
 	// Timeout for DICOM operations (in seconds)
 	Timeout int `json:"Timeout,omitempty"`
@@ -84,7 +84,7 @@ type ModalityStoreRequest struct {
 	Resources []string `json:"Resources,omitempty"`
 
 	// Whether to synchronously wait for the transfer
-	Synchronous bool `json:"Synchronous,omitempty"`
+	Synchronous *bool `json:"Synchronous,omitempty"`
 
 	// Local AET to use for the transfer
 	LocalAet string `json:"LocalAet,omitempty"`
@@ -136,7 +136,7 @@ type ModalityFindRequest struct {
 	Query map[string]string `json:"Query"`
 
 	// Whether to normalize the query
-	Normalize bool `json:"Normalize,omitempty"`
+	Normalize *bool `json:"Normalize,omitempty"`
 
 	// Timeout in seconds
 	Timeout int `json:"Timeout,omitempty"`
@@ -171,9 +171,9 @@ type ModalityMoveRequest struct {
 
 	Priority int `json:"Priority,omitempty"`
 
-	Permissive bool `json:"Permissive,omitempty"`
-	
-	Asynchronous bool `json:"Asynchronous,omitempty"`
+	Permissive *bool `json:"Permissive,omitempty"`
+
+	Asynchronous *bool `json:"Asynchronous,omitempty"`
 
 	// Timeout in seconds
 	Timeout int `json:"Timeout,omitempty"`
@@ -209,8 +209,8 @@ type ModalityGetRequest struct {
 	Timeout int `json:"Timeout,omitempty"`
 
 	// If true, ignore errors during the individual steps of the job.
-	Permissive bool `json:"Permissive,omitempty"`
-	
+	Permissive *bool `json:"Permissive,omitempty"`
+
 	// If true, run the job in asynchronous mode,
-	Asynchronous bool `json:"Asynchronous,omitempty"`
+	Asynchronous *bool `json:"Asynchronous,omitempty"`
 }

--- a/types/patient.go
+++ b/types/patient.go
@@ -93,19 +93,19 @@ type PatientStatistics struct {
 // AnonymizeRequest represents a request to anonymize a series
 type PatientAnonymizeRequest struct {
 	// If true, the REST API will return a Job ID and the job will be put in a queue
-	Asynchronous bool `json:"Asynchronous,omitempty"`
+	Asynchronous *bool `json:"Asynchronous,omitempty"`
 
 	// DicomVersion to use for anonymization
 	DicomVersion string `json:"DicomVersion,omitempty"`
 
 	// Force operation even if it would create an invalid DICOM file
-	Force bool `json:"Force,omitempty"`	
+	Force *bool `json:"Force,omitempty"`
 
 	// By default orthanc does not exclude the source series, use set this to falso to delete after the anonymization proccess
-	KeepSource bool `json:"KeepSource,omitempty"`	
+	KeepSource *bool `json:"KeepSource,omitempty"`
 
 	// If true, ignore errors during the individual steps of the job.
-	Permissive bool `json:"Permissive,omitempty"`
+	Permissive *bool `json:"Permissive,omitempty"`
 
 	// Defines the priority of the job (Only work on async mode, which isn't implemented)
 	Priority int `json:"Priority,omitempty"`

--- a/types/series.go
+++ b/types/series.go
@@ -117,19 +117,19 @@ type SeriesQueryParams struct {
 // AnonymizeRequest represents a request to anonymize a series
 type SeriesAnonymizeRequest struct {
 	// If true, the REST API will return a Job ID and the job will be put in a queue
-	Asynchronous bool `json:"Asynchronous,omitempty"`
+	Asynchronous *bool `json:"Asynchronous,omitempty"`
 
 	// DicomVersion to use for anonymization
 	DicomVersion string `json:"DicomVersion,omitempty"`
 
 	// Force operation even if it would create an invalid DICOM file
-	Force bool `json:"Force,omitempty"`	
+	Force *bool `json:"Force,omitempty"`
 
 	// By default orthanc does not exclude the source series, use set this to falso to delete after the anonymization proccess
-	KeepSource bool `json:"KeepSource,omitempty"`	
+	KeepSource *bool `json:"KeepSource,omitempty"`
 
 	// If true, ignore errors during the individual steps of the job.
-	Permissive bool `json:"Permissive,omitempty"`
+	Permissive *bool `json:"Permissive,omitempty"`
 
 	// Defines the priority of the job (Only work on async mode, which isn't implemented)
 	Priority int `json:"Priority,omitempty"`

--- a/types/study.go
+++ b/types/study.go
@@ -100,28 +100,28 @@ type ModifyRequest struct {
 	Keep []string `json:"Keep,omitempty"`
 
 	// Whether to keep private tags
-	KeepPrivateTags bool `json:"KeepPrivateTags,omitempty"`
+	KeepPrivateTags *bool `json:"KeepPrivateTags,omitempty"`
 
 	// Force operation even if it would create an invalid DICOM file
-	Force bool `json:"Force,omitempty"`
+	Force *bool `json:"Force,omitempty"`
 }
 
 // AnonymizeRequest represents a request to anonymize a study
 type StudyAnonymizeRequest struct {
 	// If true, the REST API will return a Job ID and the job will be put in a queue
-	Asynchronous bool `json:"Asynchronous,omitempty"`
+	Asynchronous *bool `json:"Asynchronous,omitempty"`
 
 	// DicomVersion to use for anonymization
 	DicomVersion string `json:"DicomVersion,omitempty"`
 
 	// Force operation even if it would create an invalid DICOM file
-	Force bool `json:"Force,omitempty"`	
+	Force *bool `json:"Force,omitempty"`
 
 	// By default orthanc does not exclude the source study, use set this to falso to delete after the anonymization proccess
-	KeepSource bool `json:"KeepSource,omitempty"`	
+	KeepSource *bool `json:"KeepSource,omitempty"`
 
 	// If true, ignore errors during the individual steps of the job.
-	Permissive bool `json:"Permissive,omitempty"`
+	Permissive *bool `json:"Permissive,omitempty"`
 
 	// Defines the priority of the job (Only work on async mode, which isn't implemented)
 	Priority int `json:"Priority,omitempty"`

--- a/types/system.go
+++ b/types/system.go
@@ -45,8 +45,8 @@ type SystemInfo struct {
 	MaximumPatients int `json:"MaximumPatients,omitempty"`
 
 	// Whether storage compression is enabled
-	StorageCompression bool `json:"StorageCompression,omitempty"`
+	StorageCompression *bool `json:"StorageCompression,omitempty"`
 
 	// Whether instance overwriting is enabled
-	OverwriteInstances bool `json:"OverwriteInstances,omitempty"`
+	OverwriteInstances *bool `json:"OverwriteInstances,omitempty"`
 }


### PR DESCRIPTION
Closes #2 

Change boolean fields with omitempty from bool to *bool to allow explicitly sending false values to the API. Add BoolPtr() helper function for cleaner pointer creation.